### PR TITLE
优化重复调用getSize导致的性能问题

### DIFF
--- a/tiklab-arbess-server/src/main/java/io/tiklab/arbess/setting/other/service/ResourcesServiceImpl.java
+++ b/tiklab-arbess-server/src/main/java/io/tiklab/arbess/setting/other/service/ResourcesServiceImpl.java
@@ -149,9 +149,10 @@ public class ResourcesServiceImpl implements ResourcesService {
         resources.setResidueCcyNumber(Math.max(i, 0));
 
         // 磁盘数（社区版不限制磁盘大小）
-        double size = Double.parseDouble(String.format("%.2f",notVipCacheNTime - getSize()));
+        double sizeCache = getSize();
+        double size = Double.parseDouble(String.format("%.2f",notVipCacheNTime - sizeCache));
         resources.setResidueCacheNumber(size);
-        double parsed = Double.parseDouble(String.format("%.2f", getSize()));
+        double parsed = Double.parseDouble(String.format("%.2f", sizeCache));
         resources.setUseCacheNumber(parsed);
 
         resources.setResidueSceNumber(-1);


### PR DESCRIPTION
**问题分析**
在 notVipResources 方法中，getSize() 方法被调用两次
两次调用执行完全相同的文件系统遍历操作
当目录结构复杂时，会造成显著的性能损耗,如图日志
<img width="1586" height="370" alt="image" src="https://github.com/user-attachments/assets/b8490041-bfba-4f83-95ee-dd5d865bec81" />
**优化方案**
将 getSize() 的结果缓存后重复使用